### PR TITLE
Nested books49

### DIFF
--- a/src/main/java/com/free_open_university/backend/bean/BookCategory.java
+++ b/src/main/java/com/free_open_university/backend/bean/BookCategory.java
@@ -10,19 +10,11 @@ public class BookCategory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "book_id")
-    private Long book_id;
     @Column(name = "category_id")
     private Long category_id;
+    @Column(name = "book_id")
+    private Long book_id;
 
-
-    public Long getBookId() {
-        return book_id;
-    }
-
-    public void getBookId(Long book_id) {
-        this.book_id = book_id;
-    }
 
     public Long getCategoryId() {
         return category_id;
@@ -32,4 +24,16 @@ public class BookCategory {
         this.category_id = category_id;
     }
 
+    public Long getBookId() {
+        return book_id;
+    }
+
+    public void getBookId(Long book_id) {
+        this.book_id = book_id;
+    }
+
+    @Override
+    public String toString() {
+        return "BookCategory [category_id=" + category_id + ", book_id=" + book_id + "]";
+    }
 }

--- a/src/main/java/com/free_open_university/backend/bean/BookCategory.java
+++ b/src/main/java/com/free_open_university/backend/bean/BookCategory.java
@@ -1,0 +1,35 @@
+package com.free_open_university.backend.bean;
+
+import javax.persistence.*;
+import java.util.Set;
+
+
+@Entity
+@Table(name = "BookCategory")
+public class BookCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_id")
+    private Long book_id;
+    @Column(name = "category_id")
+    private Long category_id;
+
+
+    public Long getBookId() {
+        return book_id;
+    }
+
+    public void getBookId(Long book_id) {
+        this.book_id = book_id;
+    }
+
+    public Long getCategoryId() {
+        return category_id;
+    }
+
+    public void setCategoryId(Long category_id) {
+        this.category_id = category_id;
+    }
+
+}

--- a/src/main/java/com/free_open_university/backend/bean/Category.java
+++ b/src/main/java/com/free_open_university/backend/bean/Category.java
@@ -18,7 +18,7 @@ public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
-    private int id;
+    private Long id;
 
     @Column(name = "name")
     private String name;
@@ -33,11 +33,11 @@ public class Category {
         )
     private Set<Book> books;
     
-    public int getId() { 
+    public Long getId() {
         return id; 
     }
 
-    public void setId(int id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/free_open_university/backend/bean/Category.java
+++ b/src/main/java/com/free_open_university/backend/bean/Category.java
@@ -23,7 +23,7 @@ public class Category {
     @Column(name = "name")
     private String name;
     @Column(name = "image_id")
-    private long imageId;
+    private Long imageId;
 
     @ManyToMany(cascade = CascadeType.ALL)
     @JoinTable (
@@ -49,19 +49,19 @@ public class Category {
         this.name = name;
     }
 
-    public Set<Book> getBooks() {
-        return books;
-    }
+//    public Set<Book> getBooks() {
+//        return books;
+//    }
+//
+//    public void setBooks(Set<Book> books) {
+//        this.books = books;
+//    }
 
-    public void setBooks(Set<Book> books) {
-        this.books = books;
-    }
-
-    public long getImageId() {
+    public Long getImageId() {
         return imageId;
     }
 
-    public void setImageId(long imageId) {
+    public void setImageId(Long imageId) {
         this.imageId = imageId;
     }
 }

--- a/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
@@ -1,0 +1,32 @@
+package com.free_open_university.backend.controller;
+
+import com.free_open_university.backend.bean.BookCategory;
+import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.dao.BookCategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+public class BookCategoryController {
+
+    @Autowired
+    BookCategoryRepository bookCategoryRepository;
+
+    @GetMapping("/bookcategory")
+    public List<BookCategory> getAllBookCategories()
+    {
+        return bookCategoryRepository.findAll();
+    }
+
+
+    @GetMapping("/bookcategory/{category_id}")
+    public Optional<BookCategory> getBookCategoryById(@PathVariable(value="category_id") Long category_id)
+    {
+        return bookCategoryRepository.findById(category_id);
+    }
+}

--- a/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
@@ -3,19 +3,25 @@ package com.free_open_university.backend.controller;
 import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import com.free_open_university.backend.dao.BookCategoryRepository;
+import com.free_open_university.backend.service.BookCategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @RestController
+//@RequestMapping("/api")
 public class BookCategoryController {
 
     @Autowired
     BookCategoryRepository bookCategoryRepository;
+    BookCategoryService bookCategoryService;
+
 
     @GetMapping("/bookcategory")
     public List<BookCategory> getAllBookCategories()
@@ -23,10 +29,8 @@ public class BookCategoryController {
         return bookCategoryRepository.findAll();
     }
 
-
     @GetMapping("/bookcategory/{category_id}")
-    public Optional<BookCategory> getBookCategoryById(@PathVariable(value="category_id") Long category_id)
-    {
-        return bookCategoryRepository.findById(category_id);
+    public List<BookCategory> findByIds(@PathVariable () List<Long> category_id) {
+        return bookCategoryRepository.findAllById(category_id);
     }
 }

--- a/src/main/java/com/free_open_university/backend/controller/CategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/CategoryController.java
@@ -1,24 +1,40 @@
 package com.free_open_university.backend.controller;
 
 import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.repositories.CategoryRepository;
 import com.free_open_university.backend.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @RestController
-@RequestMapping("/category")
+//@RequestMapping("/category")
 public class CategoryController {
 
     @Autowired
-    CategoryService categoryService;
+//    CategoryService categoryService;
+    CategoryRepository categoryRepository;
 
-    @GetMapping
-    public List<Category> getAllCategories() {
-        return categoryService.getAllCategories();
+//    @GetMapping
+//    public List<Category> getAllCategories() {
+//        return categoryService.getAllCategories();
+//    }
+
+    @GetMapping("/category")
+    public List<Category> getAllCategories()
+    {
+        return categoryRepository.findAll();
+    }
+
+    @GetMapping("/category/{id}")
+    public Optional<Category> getCategoryById(@PathVariable(value="id") Long id)
+    {
+        return categoryRepository.findById(id);
     }
 }

--- a/src/main/java/com/free_open_university/backend/controller/CategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/CategoryController.java
@@ -1,6 +1,9 @@
 package com.free_open_university.backend.controller;
 
+import com.free_open_university.backend.bean.Book;
+import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.repositories.BookRepository;
 import com.free_open_university.backend.repositories.CategoryRepository;
 import com.free_open_university.backend.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +23,7 @@ public class CategoryController {
     @Autowired
 //    CategoryService categoryService;
     CategoryRepository categoryRepository;
+    BookRepository bookRepository;
 
 //    @GetMapping
 //    public List<Category> getAllCategories() {
@@ -37,4 +41,16 @@ public class CategoryController {
     {
         return categoryRepository.findById(id);
     }
+
+//    @GetMapping("/category/{id}/books")
+//    public List<Category> getBooksbyCategory(@PathVariable(value="books") Long books)
+//    {
+//        return categoryRepository.findBooksByCategory(books);
+//    }
+
+//    @GetMapping("/category/{id}/books")
+//    public List<BookCategory> getBooksbyCategory(@PathVariable(value="books") Long book_id)
+//    {
+//        return categoryRepository.findBooksByCategory(book_id);
+//    }
 }

--- a/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
@@ -4,9 +4,10 @@ import com.free_open_university.backend.bean.BookCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
 
 //    List<BookCategory> findBooksByBookCategory(Long category_id);
-
+//    List<BookCategory> findAllById(Long category_id);
 }

--- a/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
@@ -1,0 +1,12 @@
+package com.free_open_university.backend.dao;
+
+import com.free_open_university.backend.bean.BookCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
+
+//    List<BookCategory> findBooksByBookCategory(Long category_id);
+
+}

--- a/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
@@ -1,10 +1,17 @@
 package com.free_open_university.backend.repositories;
 
+//import com.free_open_university.backend.bean.Book;
+import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+//    List<Category> findBooksByCategory(Long book_id);
+
 }
+

--- a/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Set;
 
-public interface CategoryRepository extends JpaRepository<Category, Integer> {
+public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class BookCategoryService {
@@ -14,9 +15,10 @@ public class BookCategoryService {
     @Autowired
     BookCategoryRepository bookCategoryRepository;
 
-    public List<BookCategory> getAllBookCategories() {
-        return bookCategoryRepository.findAll();
-    }
+//    public List<BookCategory> getAllBookCategories() {
+//        return bookCategoryRepository.findAll();
+//    }
 
-//    public List<BookCategory> getBooksbyCategory(Long category_id) { return bookCategoryRepository.findBooksByCategory(category_id); }
+//    public List<BookCategory> getBooksbyCategoryId(Long category_id) { return bookCategoryRepository.findAllById(category_id); }
+
 }

--- a/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
@@ -1,0 +1,22 @@
+package com.free_open_university.backend.service;
+
+import com.free_open_university.backend.bean.BookCategory;
+import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.dao.BookCategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class BookCategoryService {
+
+    @Autowired
+    BookCategoryRepository bookCategoryRepository;
+
+    public List<BookCategory> getAllBookCategories() {
+        return bookCategoryRepository.findAll();
+    }
+
+//    public List<BookCategory> getBooksbyCategory(Long category_id) { return bookCategoryRepository.findBooksByCategory(category_id); }
+}

--- a/src/main/java/com/free_open_university/backend/service/CategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/CategoryService.java
@@ -1,11 +1,14 @@
 package com.free_open_university.backend.service;
 
+import com.free_open_university.backend.bean.Book;
+import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import com.free_open_university.backend.repositories.CategoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -18,4 +21,7 @@ public class CategoryService {
         return categoryRepository.findAll();
     }
 
+//    public List<Category> getBooksbyCategory(Long books) { return categoryRepository.findBooksByCategory(books); }
+
+//    public List<BookCategory> getBooksbyCategory(Long book_id) { return categoryRepository.findBooksByCategory(book_id); }
 }


### PR DESCRIPTION
**#49 API for GET books by category**

## Issues

1. Removal of nested `books` meant I couldn't have books show up again as an API endpoint for category
    - _I think we should indeed remove it since the list can get supposedly 100 books long for simply doing a `http://localhost:8080/category` request_
2. the books + category relationship is only in `bookcategory` so it was easier to create a model from that. Otherwise, I tried importing the book/category relationships into category but the CRUD functions didn't work


## Solution
In the end, this is what ended up working. Simply requesting `/category` and `/bookcategory` will return the entire table as a `findAll` request:

**`http://localhost:8080/category/4`**
**`http://localhost:8080/bookcategory/4,5,6`**

I can also change these APIs if we change the database schema. I also found this [Pagination & Filter](https://bezkoder.com/spring-boot-pagination-filter-jpa-pageable/) post which is what I assumed we were trying to do but I think our scenario is different.