### PR TITLE
Bookcategoryfix

### DIFF
--- a/database/init_script.sql
+++ b/database/init_script.sql
@@ -48,9 +48,10 @@ CREATE TABLE IF NOT EXISTS Book (
 );
 
 CREATE TABLE IF NOT EXISTS BookCategory (
+    bookcategory_id INT NOT Null AUTO_INCREMENT,
 	book_id INT NOT NULL,
 	category_id INT NOT NULL,
-	PRIMARY KEY (book_id, category_id),
+	PRIMARY KEY (bookcategory_id, book_id, category_id),
 	KEY fk_book (book_id),
 	KEY fk_category (category_id),
 	CONSTRAINT fk_book FOREIGN KEY (book_id) REFERENCES Book (book_id),

--- a/src/main/java/com/free_open_university/backend/bean/Book.java
+++ b/src/main/java/com/free_open_university/backend/bean/Book.java
@@ -24,7 +24,7 @@ public class Book {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "book_id")
-    private int id;
+    private Long id;
 
     @Column(name = "title")
     private String title;
@@ -50,11 +50,11 @@ public class Book {
     
     // private Category categoryList;
 
-    public int getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/free_open_university/backend/bean/BookCategory.java
+++ b/src/main/java/com/free_open_university/backend/bean/BookCategory.java
@@ -12,6 +12,7 @@ public class BookCategory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "bookcategory_id")
     private Long bookcategory_id;
+
     @Column(name = "category_id")
     private Long category_id;
     @Column(name = "book_id")

--- a/src/main/java/com/free_open_university/backend/bean/BookCategory.java
+++ b/src/main/java/com/free_open_university/backend/bean/BookCategory.java
@@ -10,19 +10,11 @@ public class BookCategory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "book_id")
-    private Long book_id;
     @Column(name = "category_id")
     private Long category_id;
+    @Column(name = "book_id")
+    private Long book_id;
 
-
-    public Long getBookId() {
-        return book_id;
-    }
-
-    public void getBookId(Long book_id) {
-        this.book_id = book_id;
-    }
 
     public Long getCategoryId() {
         return category_id;
@@ -32,4 +24,16 @@ public class BookCategory {
         this.category_id = category_id;
     }
 
+    public Long getBookId() {
+        return book_id;
+    }
+
+    public void getBookId(Long book_id) {
+        this.book_id = book_id;
+    }
+
+    @Override
+    public String toString() {
+        return "BookCategory [category_id=" + category_id + ", book_id=" + book_id + "]";
+    }
 }

--- a/src/main/java/com/free_open_university/backend/bean/BookCategory.java
+++ b/src/main/java/com/free_open_university/backend/bean/BookCategory.java
@@ -1,0 +1,35 @@
+package com.free_open_university.backend.bean;
+
+import javax.persistence.*;
+import java.util.Set;
+
+
+@Entity
+@Table(name = "BookCategory")
+public class BookCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_id")
+    private Long book_id;
+    @Column(name = "category_id")
+    private Long category_id;
+
+
+    public Long getBookId() {
+        return book_id;
+    }
+
+    public void getBookId(Long book_id) {
+        this.book_id = book_id;
+    }
+
+    public Long getCategoryId() {
+        return category_id;
+    }
+
+    public void setCategoryId(Long category_id) {
+        this.category_id = category_id;
+    }
+
+}

--- a/src/main/java/com/free_open_university/backend/bean/BookCategory.java
+++ b/src/main/java/com/free_open_university/backend/bean/BookCategory.java
@@ -10,11 +10,20 @@ public class BookCategory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookcategory_id")
+    private Long bookcategory_id;
     @Column(name = "category_id")
     private Long category_id;
     @Column(name = "book_id")
     private Long book_id;
 
+    public Long getBookCategoryId() {
+        return bookcategory_id;
+    }
+
+    public void setBookCategoryId(Long bookcategory_id) {
+        this.bookcategory_id = bookcategory_id;
+    }
 
     public Long getCategoryId() {
         return category_id;
@@ -32,8 +41,8 @@ public class BookCategory {
         this.book_id = book_id;
     }
 
-    @Override
-    public String toString() {
-        return "BookCategory [category_id=" + category_id + ", book_id=" + book_id + "]";
-    }
+//    @Override
+//    public String toString() {
+//        return "BookCategory [category_id=" + category_id + ", book_id=" + book_id + "]";
+//    }
 }

--- a/src/main/java/com/free_open_university/backend/bean/Category.java
+++ b/src/main/java/com/free_open_university/backend/bean/Category.java
@@ -18,7 +18,7 @@ public class Category {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")
-    private int id;
+    private Long id;
 
     @Column(name = "name")
     private String name;
@@ -33,11 +33,11 @@ public class Category {
         )
     private Set<Book> books;
     
-    public int getId() { 
+    public Long getId() {
         return id; 
     }
 
-    public void setId(int id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/com/free_open_university/backend/bean/Category.java
+++ b/src/main/java/com/free_open_university/backend/bean/Category.java
@@ -23,7 +23,7 @@ public class Category {
     @Column(name = "name")
     private String name;
     @Column(name = "image_id")
-    private long imageId;
+    private Long imageId;
 
     @ManyToMany(cascade = CascadeType.ALL)
     @JoinTable (
@@ -49,19 +49,19 @@ public class Category {
         this.name = name;
     }
 
-    public Set<Book> getBooks() {
-        return books;
-    }
+//    public Set<Book> getBooks() {
+//        return books;
+//    }
+//
+//    public void setBooks(Set<Book> books) {
+//        this.books = books;
+//    }
 
-    public void setBooks(Set<Book> books) {
-        this.books = books;
-    }
-
-    public long getImageId() {
+    public Long getImageId() {
         return imageId;
     }
 
-    public void setImageId(long imageId) {
+    public void setImageId(Long imageId) {
         this.imageId = imageId;
     }
 }

--- a/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
@@ -1,0 +1,32 @@
+package com.free_open_university.backend.controller;
+
+import com.free_open_university.backend.bean.BookCategory;
+import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.dao.BookCategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+public class BookCategoryController {
+
+    @Autowired
+    BookCategoryRepository bookCategoryRepository;
+
+    @GetMapping("/bookcategory")
+    public List<BookCategory> getAllBookCategories()
+    {
+        return bookCategoryRepository.findAll();
+    }
+
+
+    @GetMapping("/bookcategory/{category_id}")
+    public Optional<BookCategory> getBookCategoryById(@PathVariable(value="category_id") Long category_id)
+    {
+        return bookCategoryRepository.findById(category_id);
+    }
+}

--- a/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
@@ -3,19 +3,25 @@ package com.free_open_university.backend.controller;
 import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import com.free_open_university.backend.dao.BookCategoryRepository;
+import com.free_open_university.backend.service.BookCategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @RestController
+//@RequestMapping("/api")
 public class BookCategoryController {
 
     @Autowired
     BookCategoryRepository bookCategoryRepository;
+    BookCategoryService bookCategoryService;
+
 
     @GetMapping("/bookcategory")
     public List<BookCategory> getAllBookCategories()
@@ -23,10 +29,8 @@ public class BookCategoryController {
         return bookCategoryRepository.findAll();
     }
 
-
     @GetMapping("/bookcategory/{category_id}")
-    public Optional<BookCategory> getBookCategoryById(@PathVariable(value="category_id") Long category_id)
-    {
-        return bookCategoryRepository.findById(category_id);
+    public List<BookCategory> findByIds(@PathVariable () List<Long> category_id) {
+        return bookCategoryRepository.findAllById(category_id);
     }
 }

--- a/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
@@ -1,5 +1,6 @@
 package com.free_open_university.backend.controller;
 
+import com.free_open_university.backend.bean.Book;
 import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import com.free_open_university.backend.dao.BookCategoryRepository;
@@ -23,14 +24,25 @@ public class BookCategoryController {
     BookCategoryService bookCategoryService;
 
 
-    @GetMapping("/bookcategory")
-    public List<BookCategory> getAllBookCategories()
-    {
-        return bookCategoryRepository.findAll();
-    }
+//    @GetMapping("/bookcategory")
+//    public List<BookCategory> getAllBookCategories()
+//    {
+//        return bookCategoryRepository.findAll();
+//    }
 
-    @GetMapping("/bookcategory/{category_id}")
-    public List<BookCategory> findByIds(@PathVariable () List<Long> category_id) {
-        return bookCategoryRepository.findAllById(category_id);
+    @GetMapping
+    public List<BookCategory> getAllBookCategories(
+            @RequestParam(value = "category_id", required = false) Long category_id) {
+        if (category_id != null) {
+            return bookCategoryService.getBooksByCategories(category_id);
+        } else {
+            return bookCategoryRepository.findAll();
+        }
+
     }
 }
+
+//    @GetMapping("/bookcategory/{category_id}")
+//    public List<BookCategory> findByIds(@PathVariable () List<Long> category_id) {
+//        return bookCategoryRepository.findAllById(category_id);
+//    }

--- a/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookCategoryController.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @RestController
-//@RequestMapping("/api")
+@RequestMapping("/bookcategory")
 public class BookCategoryController {
 
     @Autowired
@@ -24,25 +24,29 @@ public class BookCategoryController {
     BookCategoryService bookCategoryService;
 
 
-//    @GetMapping("/bookcategory")
-//    public List<BookCategory> getAllBookCategories()
-//    {
-//        return bookCategoryRepository.findAll();
-//    }
-
-    @GetMapping
-    public List<BookCategory> getAllBookCategories(
-            @RequestParam(value = "category_id", required = false) Long category_id) {
-        if (category_id != null) {
-            return bookCategoryService.getBooksByCategories(category_id);
-        } else {
-            return bookCategoryRepository.findAll();
-        }
-
+    @GetMapping //("/bookcategory")
+    public List<BookCategory> getAllBookCategories()
+    {
+        return bookCategoryRepository.findAll();
     }
-}
 
-//    @GetMapping("/bookcategory/{category_id}")
+//    @GetMapping
+//    public List<BookCategory> getAllBookCategories(
+//            @RequestParam(value = "category_id", required = false) Long category_id) {
+//        if (category_id != null) {
+//            return bookCategoryService.getBooksByCategories(category_id);
+//        } else {
+////            return bookCategoryService.getAllBookCategories();
+//            return bookCategoryRepository.findAll();
+//        }
+
+////        This won't work because it has to be /bookcategory/{bookcategory_id}
+//        @GetMapping("/bookcategory/{category_id}")
 //    public List<BookCategory> findByIds(@PathVariable () List<Long> category_id) {
 //        return bookCategoryRepository.findAllById(category_id);
 //    }
+
+
+}
+
+

--- a/src/main/java/com/free_open_university/backend/controller/BookController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookController.java
@@ -5,6 +5,7 @@ import com.free_open_university.backend.http.Response;
 import com.free_open_university.backend.repositories.BookRepository;
 import com.free_open_university.backend.service.BookService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,10 +50,20 @@ public class BookController {
 //        return bookService.addBook(newBook);
 //    }
 
-    @PostMapping("/upload")
-    public Book addBook(@RequestBody Book book)
+
+    @DeleteMapping("/deleteBook/{book_id}")
+    private void deleteBook(@PathVariable("book_id") Long id)
     {
-        return bookRepository.save(book);
+        bookService.delete(id);
+    }
+
+    @PostMapping("/addBook")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    private Long addBook(@RequestBody Book book)
+
+    {
+        bookService.saveOrUpdate(book);
+        return book.getId();
     }
 
     @PostMapping("/batch_upload")
@@ -66,5 +77,14 @@ public class BookController {
         }
         return new Response(true,200,"books added");
     }
+
+    @PutMapping("/updateBook")
+    private Book updateBook(@RequestBody Book book)
+    {
+        bookService.saveOrUpdate(book);
+        return book;
+    }
+
+
 
 }

--- a/src/main/java/com/free_open_university/backend/controller/BookController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookController.java
@@ -45,20 +45,9 @@ public class BookController {
         // }
     }
 
-//    @PostMapping
-//    public Response addBook(@RequestBody  Book newBook) {
-//        return bookService.addBook(newBook);
-//    }
-
-
-    @DeleteMapping("/deleteBook/{book_id}")
-    private void deleteBook(@PathVariable("book_id") Long id)
-    {
-        bookService.delete(id);
-    }
 
     @PostMapping("/addBook")
-    @ResponseStatus(HttpStatus.ACCEPTED)
+//    @ResponseStatus(HttpStatus.ACCEPTED)
     private Long addBook(@RequestBody Book book)
 
     {
@@ -66,17 +55,22 @@ public class BookController {
         return book.getId();
     }
 
-    @PostMapping("/batch_upload")
-    public Response addBookBatch(@RequestBody Set<Book> books) {
-        Response response = new Response();
-        for (Book book : books) {
-            response = bookService.addBook(book);
-            if(!response.isSuccess()) {
-                return response;
-            }
-        }
-        return new Response(true,200,"books added");
+    @PostMapping("/addBooks")
+    public List<Book> saveAllBook(@RequestBody List<Book> bookList) {
+        return (List<Book>) bookService.saveAllBook(bookList);
     }
+
+    @DeleteMapping("/deleteBook/{book_id}")
+    private void deleteBook(@PathVariable("book_id") Long id)
+    {
+        bookService.delete(id);
+    }
+
+//    @DeleteMapping("/deleteBooks")
+//    public String deleteInBatch(@RequestBody List<Book> bookList) {
+//        bookService.deleteInBatch(bookList);
+//        return "All Students deleted successfully";
+//    }
 
     @PutMapping("/updateBook")
     private Book updateBook(@RequestBody Book book)
@@ -85,6 +79,17 @@ public class BookController {
         return book;
     }
 
-
-
 }
+
+
+//    @PostMapping("/batch_upload")
+//    public Response addBookBatch(@RequestBody Set<Book> books) {
+//        Response response = new Response();
+//        for (Book book : books) {
+//            response = bookService.addBook(book);
+//            if(!response.isSuccess()) {
+//                return response;
+//            }
+//        }
+//        return new Response(true,200,"books added");
+//    }

--- a/src/main/java/com/free_open_university/backend/controller/BookController.java
+++ b/src/main/java/com/free_open_university/backend/controller/BookController.java
@@ -2,6 +2,7 @@ package com.free_open_university.backend.controller;
 
 import com.free_open_university.backend.bean.Book;
 import com.free_open_university.backend.http.Response;
+import com.free_open_university.backend.repositories.BookRepository;
 import com.free_open_university.backend.service.BookService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ public class BookController {
 
     @Autowired
     BookService bookService;
+    BookRepository bookRepository;
 
 /*    @GetMapping // todo: need another path
     public Book getBookByTitle(@RequestParam(value = "title") String title) {
@@ -42,9 +44,15 @@ public class BookController {
         // }
     }
 
-    @PostMapping
-    public Response addBook(@RequestBody  Book newBook) {
-        return bookService.addBook(newBook);
+//    @PostMapping
+//    public Response addBook(@RequestBody  Book newBook) {
+//        return bookService.addBook(newBook);
+//    }
+
+    @PostMapping("/upload")
+    public Book addBook(@RequestBody Book book)
+    {
+        return bookRepository.save(book);
     }
 
     @PostMapping("/batch_upload")

--- a/src/main/java/com/free_open_university/backend/controller/CategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/CategoryController.java
@@ -1,24 +1,40 @@
 package com.free_open_university.backend.controller;
 
 import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.repositories.CategoryRepository;
 import com.free_open_university.backend.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @RestController
-@RequestMapping("/category")
+//@RequestMapping("/category")
 public class CategoryController {
 
     @Autowired
-    CategoryService categoryService;
+//    CategoryService categoryService;
+    CategoryRepository categoryRepository;
 
-    @GetMapping
-    public List<Category> getAllCategories() {
-        return categoryService.getAllCategories();
+//    @GetMapping
+//    public List<Category> getAllCategories() {
+//        return categoryService.getAllCategories();
+//    }
+
+    @GetMapping("/category")
+    public List<Category> getAllCategories()
+    {
+        return categoryRepository.findAll();
+    }
+
+    @GetMapping("/category/{id}")
+    public Optional<Category> getCategoryById(@PathVariable(value="id") Long id)
+    {
+        return categoryRepository.findById(id);
     }
 }

--- a/src/main/java/com/free_open_university/backend/controller/CategoryController.java
+++ b/src/main/java/com/free_open_university/backend/controller/CategoryController.java
@@ -1,6 +1,9 @@
 package com.free_open_university.backend.controller;
 
+import com.free_open_university.backend.bean.Book;
+import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.repositories.BookRepository;
 import com.free_open_university.backend.repositories.CategoryRepository;
 import com.free_open_university.backend.service.CategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +23,7 @@ public class CategoryController {
     @Autowired
 //    CategoryService categoryService;
     CategoryRepository categoryRepository;
+    BookRepository bookRepository;
 
 //    @GetMapping
 //    public List<Category> getAllCategories() {
@@ -37,4 +41,16 @@ public class CategoryController {
     {
         return categoryRepository.findById(id);
     }
+
+//    @GetMapping("/category/{id}/books")
+//    public List<Category> getBooksbyCategory(@PathVariable(value="books") Long books)
+//    {
+//        return categoryRepository.findBooksByCategory(books);
+//    }
+
+//    @GetMapping("/category/{id}/books")
+//    public List<BookCategory> getBooksbyCategory(@PathVariable(value="books") Long book_id)
+//    {
+//        return categoryRepository.findBooksByCategory(book_id);
+//    }
 }

--- a/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
@@ -4,9 +4,10 @@ import com.free_open_university.backend.bean.BookCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
 
 //    List<BookCategory> findBooksByBookCategory(Long category_id);
-
+//    List<BookCategory> findAllById(Long category_id);
 }

--- a/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
@@ -1,0 +1,12 @@
+package com.free_open_university.backend.dao;
+
+import com.free_open_university.backend.bean.BookCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BookCategoryRepository extends JpaRepository<BookCategory, Long> {
+
+//    List<BookCategory> findBooksByBookCategory(Long category_id);
+
+}

--- a/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
@@ -1,7 +1,9 @@
 package com.free_open_university.backend.dao;
 
+import com.free_open_university.backend.bean.Book;
 import com.free_open_university.backend.bean.BookCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,16 @@ public interface BookCategoryRepository extends JpaRepository<BookCategory, Long
 
 //    List<BookCategory> findBooksByBookCategory(Long category_id);
 //    List<BookCategory> findAllById(Long category_id);
+
+
+
+//    @Query("SELECT new com.roytuts.spring.data.jpa.left.right.inner.cross.join.dto.JoinDto(BookCategory.category_id, BookCategory.book_id, Book.title "
+//            + "FROM Sale s INNER JOIN s.food f INNER JOIN f.company c")
+//    List<JoinDto> fetchDataInnerJoin();
+//
+//    SELECT BookCategory.category_id, BookCategory.book_id, Book.title FROM BookCategory INNER JOIN Book ON BookCategory.book_id=Book.book_id;
+
+    List<BookCategory> findbyCategory(Long category_id);
+
+
 }

--- a/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/dao/BookCategoryRepository.java
@@ -21,7 +21,7 @@ public interface BookCategoryRepository extends JpaRepository<BookCategory, Long
 //
 //    SELECT BookCategory.category_id, BookCategory.book_id, Book.title FROM BookCategory INNER JOIN Book ON BookCategory.book_id=Book.book_id;
 
-    List<BookCategory> findbyCategory(Long category_id);
+//    List<BookCategory> findbyCategory(Long category_id);
 
 
 }

--- a/src/main/java/com/free_open_university/backend/repositories/BookRepository.java
+++ b/src/main/java/com/free_open_university/backend/repositories/BookRepository.java
@@ -5,11 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Set;
 import java.util.Optional;
 
-public interface BookRepository extends JpaRepository<Book, Long> {
+public interface BookRepository extends JpaRepository<Book, Serializable> {
 
     Optional<Book> findByTitle(String title);
 

--- a/src/main/java/com/free_open_university/backend/repositories/BookRepository.java
+++ b/src/main/java/com/free_open_university/backend/repositories/BookRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Optional;
 
-public interface BookRepository extends JpaRepository<Book, Integer> {
+public interface BookRepository extends JpaRepository<Book, Long> {
 
     Optional<Book> findByTitle(String title);
 

--- a/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
@@ -1,10 +1,17 @@
 package com.free_open_university.backend.repositories;
 
+//import com.free_open_university.backend.bean.Book;
+import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+//    List<Category> findBooksByCategory(Long book_id);
+
 }
+

--- a/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
+++ b/src/main/java/com/free_open_university/backend/repositories/CategoryRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Set;
 
-public interface CategoryRepository extends JpaRepository<Category, Integer> {
+public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
@@ -1,5 +1,6 @@
 package com.free_open_university.backend.service;
 
+import com.free_open_university.backend.bean.Book;
 import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import com.free_open_university.backend.dao.BookCategoryRepository;
@@ -15,9 +16,13 @@ public class BookCategoryService {
     @Autowired
     BookCategoryRepository bookCategoryRepository;
 
-//    public List<BookCategory> getAllBookCategories() {
-//        return bookCategoryRepository.findAll();
-//    }
+    public List<BookCategory> getAllBookCategories() {
+        return bookCategoryRepository.findAll();
+    }
+
+    public List<BookCategory> getBooksByCategories(Long category_id) {
+        return bookCategoryRepository.findbyCategory(category_id);
+    }
 
 //    public List<BookCategory> getBooksbyCategoryId(Long category_id) { return bookCategoryRepository.findAllById(category_id); }
 

--- a/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class BookCategoryService {
@@ -14,9 +15,10 @@ public class BookCategoryService {
     @Autowired
     BookCategoryRepository bookCategoryRepository;
 
-    public List<BookCategory> getAllBookCategories() {
-        return bookCategoryRepository.findAll();
-    }
+//    public List<BookCategory> getAllBookCategories() {
+//        return bookCategoryRepository.findAll();
+//    }
 
-//    public List<BookCategory> getBooksbyCategory(Long category_id) { return bookCategoryRepository.findBooksByCategory(category_id); }
+//    public List<BookCategory> getBooksbyCategoryId(Long category_id) { return bookCategoryRepository.findAllById(category_id); }
+
 }

--- a/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
@@ -1,0 +1,22 @@
+package com.free_open_university.backend.service;
+
+import com.free_open_university.backend.bean.BookCategory;
+import com.free_open_university.backend.bean.Category;
+import com.free_open_university.backend.dao.BookCategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class BookCategoryService {
+
+    @Autowired
+    BookCategoryRepository bookCategoryRepository;
+
+    public List<BookCategory> getAllBookCategories() {
+        return bookCategoryRepository.findAll();
+    }
+
+//    public List<BookCategory> getBooksbyCategory(Long category_id) { return bookCategoryRepository.findBooksByCategory(category_id); }
+}

--- a/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookCategoryService.java
@@ -16,13 +16,13 @@ public class BookCategoryService {
     @Autowired
     BookCategoryRepository bookCategoryRepository;
 
-    public List<BookCategory> getAllBookCategories() {
-        return bookCategoryRepository.findAll();
-    }
+//    public List<BookCategory> getAllBookCategories() {
+//        return bookCategoryRepository.findAll();
+//    }
 
-    public List<BookCategory> getBooksByCategories(Long category_id) {
-        return bookCategoryRepository.findbyCategory(category_id);
-    }
+//    public List<BookCategory> getBooksByCategories(Long category_id) {
+//        return bookCategoryRepository.findbyCategory(category_id);
+//    }
 
 //    public List<BookCategory> getBooksbyCategoryId(Long category_id) { return bookCategoryRepository.findAllById(category_id); }
 

--- a/src/main/java/com/free_open_university/backend/service/BookService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookService.java
@@ -31,16 +31,21 @@ public class BookService {
         bookRepository.save(book);
     }
 
+    public List<Book> saveAllBook(List<Book> bookList) { return  bookRepository.saveAll(bookList); }
+
     public void delete(Long id) { bookRepository.deleteById(id); }
 
-    @Transactional
-    public Response addBook(Book newBook) {
-        try{
-            bookRepository.save(newBook);
-            return new Response(true, "book added");
-        } catch (Exception e) {
-            e.printStackTrace();
-            return new Response(false, "book not added");
-        }
+    public void deleteInBatch(List<Book> bookList) { bookRepository.deleteInBatch(bookList);
     }
+
+//    @Transactional
+//    public Response addBook(Book newBook) {
+//        try{
+//            bookRepository.save(newBook);
+//            return new Response(true, "book added");
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            return new Response(false, "book not added");
+//        }
+//    }
 }

--- a/src/main/java/com/free_open_university/backend/service/BookService.java
+++ b/src/main/java/com/free_open_university/backend/service/BookService.java
@@ -26,6 +26,13 @@ public class BookService {
         return bookRepository.findByTitle(title);
     }
 
+    public void saveOrUpdate(Book book)
+    {
+        bookRepository.save(book);
+    }
+
+    public void delete(Long id) { bookRepository.deleteById(id); }
+
     @Transactional
     public Response addBook(Book newBook) {
         try{

--- a/src/main/java/com/free_open_university/backend/service/CategoryService.java
+++ b/src/main/java/com/free_open_university/backend/service/CategoryService.java
@@ -1,11 +1,14 @@
 package com.free_open_university.backend.service;
 
+import com.free_open_university.backend.bean.Book;
+import com.free_open_university.backend.bean.BookCategory;
 import com.free_open_university.backend.bean.Category;
 import com.free_open_university.backend.repositories.CategoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 @Service
@@ -18,4 +21,7 @@ public class CategoryService {
         return categoryRepository.findAll();
     }
 
+//    public List<Category> getBooksbyCategory(Long books) { return categoryRepository.findBooksByCategory(books); }
+
+//    public List<BookCategory> getBooksbyCategory(Long book_id) { return categoryRepository.findBooksByCategory(book_id); }
 }


### PR DESCRIPTION
**Somewhat related issue: #49** 

### Problem
`BookCategory` was unable to display all data using the standard `findbyID` API and the reason being is that there was no unique identifier in the table. Both columns, `book_id` and `category_id` are foreign keys from other tables.

### Fix
![image](https://user-images.githubusercontent.com/8211605/106217767-fa30d580-61a3-11eb-9cc8-a2f5da9f2c87.png)

There is now a new column `bookcategory_id`, which will be a unique identifier (id) for each of the many-to-many relationships between books and categories so now, as you can see in the picture, `book_id: 1` and `book_id: 2` both belong in `category: 1` and so on. The `bookcategory_id` isn't something we will actually use in an endpoint but at least it displays all the values. Before it wasn't able to do that.

In the end, I only created this API to be able to use inner join to query books and categories together. It's possible all of this could have been avoided by building a query on `book` itself but I think this may make it easier to tie in books, categories, and their respective relationships. This is also important to have if you want to see all relationships between books and categories.

Also @linesbetween, I have a lot of commented out code which I may end up using for later APIs but I wanted to leave it in for now and clean it all up later.